### PR TITLE
Updated search_snipe_asset function to use the byserial endpoint inst…

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -285,5 +285,5 @@ else:
         JAMF_UP = False
     if SNIPE_UP is False:
         print('Snipe-IT looks like it is down from here. Please check your config or your instance.')
-    if SNIPE_UP is False:
+    if JAMF_UP is False:
         print('JAMFPro looks down from here. Please check the your config or your hosted JAMFPro instance.')

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -2,8 +2,8 @@
 # jamf2snipe - Inventory Import
 #
 # ABOUT:
-#   This program is designed to import inventory information from a 
-#   JAMFPro into snipe-it using api calls. For more information 
+#   This program is designed to import inventory information from a
+#   JAMFPro into snipe-it using api calls. For more information
 #   about both of these products, please visit their respecitive
 #   websites:
 #       https://jamf.com
@@ -13,15 +13,15 @@
 #   GLPv3
 #
 # CONFIGURATION:
-#   These settings are commonly found in the settings.conf file. 
-#   
-#   This setting sets the Snipe Asset status when creating a new asset. By default it's set to 4 (Pending). 
+#   These settings are commonly found in the settings.conf file.
+#
+#   This setting sets the Snipe Asset status when creating a new asset. By default it's set to 4 (Pending).
 #   defaultStatus = 4
 #
-#   You can associate snipe hardware keys in the [api-mapping] section, to to a JAMF keys so it associates 
-#   the jamf values into snipe. The default example associates information that exists by default in both 
-#   Snipe and JAMF.  The Key value is the exact name of the snipe key name. 
-#   Value1 is the "Subset" (JAMF's wording not mine) name, and the Value2 is the JAMF key name. 
+#   You can associate snipe hardware keys in the [api-mapping] section, to to a JAMF keys so it associates
+#   the jamf values into snipe. The default example associates information that exists by default in both
+#   Snipe and JAMF.  The Key value is the exact name of the snipe key name.
+#   Value1 is the "Subset" (JAMF's wording not mine) name, and the Value2 is the JAMF key name.
 #   Note that MAC Address are a custom value in SNIPE by default and you can use it as an example.
 #
 #   [api-mapping]
@@ -29,7 +29,7 @@
 #       _snipeit_mac_address_1 = general mac_address
 #       _snipeit_custom_name_1234567890 = subset jamf_key
 #
-#   A list of valid subsets are: 
+#   A list of valid subsets are:
 validsubset = (
         "general",
         "location",
@@ -118,7 +118,7 @@ def search_jamf_asset(jamf_id):
         print('JAMFPro responded with error code:{} when we tried to look up id: {}'.format(response, jamf_id))
         return None
 
-# Function to update the asset tag in JAMF with an number passed from Snipe. 
+# Function to update the asset tag in JAMF with an number passed from Snipe.
 def update_jamf_asset_tag(jamf_id, asset_tag):
     api_url = "{}/JSSResource/computers/id/{}".format(jamfpro_base, jamf_id)
     payload = """<?xml version="1.0" encoding="UTF-8"?><computer><general><id>{}</id><asset_tag>{}</asset_tag></general></computer>""".format(jamf_id, asset_tag)
@@ -134,9 +134,9 @@ def update_jamf_asset_tag(jamf_id, asset_tag):
         print('JAMFPro responded with error code:{} when we tried to update id: {}'.format(response, jamf_id))
         return False
 
-# Function to lookup a snipe asset by serial number or other identifier.
-def search_snipe_asset(search_term):
-    api_url = '{}/api/v1/hardware?search={}'.format(snipe_base, search_term)
+# Function to lookup a snipe asset by serial number.
+def search_snipe_asset(serial):
+    api_url = '{}/api/v1/hardware/byserial/{}'.format(snipe_base, serial)
     response = requests.get(api_url, headers=snipeheaders)
     if response.status_code == 200:
         jsonresponse = response.json()
@@ -144,13 +144,13 @@ def search_snipe_asset(search_term):
         if jsonresponse['total'] == 1:
             return jsonresponse
         elif jsonresponse['total'] == 0:
-            print("No assets match {}".format(search_term))
+            print("No assets match {}".format(serial))
             return "NoMatch"
         else:
-            print('WARNING: FOUND {} matching assets while searching for: {}'.format(jsonresponse['total'], search_term))
+            print('WARNING: FOUND {} matching assets while searching for: {}'.format(jsonresponse['total'], serial))
             return "MultiMatch"
     else:
-        print('Snipe-IT responded with error code:{} when we tried to look up: {}'.format(response, search_term))
+        print('Snipe-IT responded with error code:{} when we tried to look up: {}'.format(response, serial))
         return "ERROR"
 
 # Function to get all the asset models
@@ -172,7 +172,7 @@ def create_snipe_model(payload):
         jsonresponse = response.json()
         modelnumbers[jsonresponse['payload']['model_number']] = jsonresponse['payload']['id']
         return True
-    else: 
+    else:
         print('Error code: {} while trying to create a new model.'.format(response.status_code))
         return False
 
@@ -212,27 +212,27 @@ modelnumbers = {}
 for model in snipemodels['rows']:
     modelnumbers[model['model_number']] =  model['id']
 
-# Get the IDS of all active assets. 
+# Get the IDS of all active assets.
 jamf_computer_list = get_jamf_computers()
 
 # Make sure we have a good list.
 if jamf_computer_list is not None:
     print('Received a list of JAMF assets.\nUpdating inventory')
     for jamf_asset in jamf_computer_list['computers']:
-        
+
         # Search through the list by ID for all asset information
         jamf = search_jamf_asset(jamf_asset['id'])
         if jamf is None:
             continue
-        
-        # Check that the model number exists in snipe, if not create it. 
+
+        # Check that the model number exists in snipe, if not create it.
         if jamf['hardware']['model_identifier'] not in modelnumbers:
             newmodel = {"category_id":1,"manufacturer_id":apple_manufacturer_id,"name": jamf['hardware']['model'],"model_number":jamf['hardware']['model_identifier']}
             create_snipe_model(newmodel)
-        
+
         # Pass the SN from JAMF to search for a match in Snipe
         snipe = search_snipe_asset(jamf['general']['serial_number'])
-        
+
         # Create a new asset if there's no match:
         if snipe is 'NoMatch':
             print("Creating a new asset in snipe.")
@@ -248,18 +248,18 @@ if jamf_computer_list is not None:
             else:
                 create_snipe_asset(newasset)
 
-        # Log an error if there's an issue, or more than once match. 
+        # Log an error if there's an issue, or more than once match.
         elif snipe is 'MultiMatch':
             print("ERROR: You need to resolve multiple assets with the same serial number in your inventory. If you can't find them in your inventory, you might need to purge your deleted records. You can find that in the Snipe Admin settings. Skipping this serial number for now.")
         elif snipe is 'ERROR':
             print("Check your snipe instance and setup. Skipping for now.")
 
         else:
-            # Only update if JAMF has more recent info. 
+            # Only update if JAMF has more recent info.
             snipe_id = snipe['rows'][0]['id']
             snipe_time = snipe['rows'][0]['updated_at']['datetime']
             jamf_time = jamf['general']['report_date']
-            # Check to see that the JAMF record is newer than the previous snipe update. 
+            # Check to see that the JAMF record is newer than the previous snipe update.
             if jamf_time > snipe_time:
                 for snipekey in config['api-mapping']:
                     jamfsplit = config['api-mapping'][snipekey].split()
@@ -273,8 +273,8 @@ if jamf_computer_list is not None:
 ### Some Error Investigation ###
 else:
     print("Couldn't get a list of computers from JAMF. Maybe your username and password are bad?")
-    
-    # Do some tests to see if the hosts are up. 
+
+    # Do some tests to see if the hosts are up.
     try:
         SNIPE_UP = True if requests.get(snipe_base).status_code is 200 else False
     except:


### PR DESCRIPTION
…ead of search parameters.
**NOTE:** I have not actually tested the changes in my environment as I'm using my own solution to keep things up to date.

The only real benefit of my changes is that the searches can be kind of weird sometimes. By doing it this way you're searching against the serial number field as opposed to all fields of the asset (maybe you have some notes about swapping a device with another device and the search will pick up that device because the notes field references the serial number).

My Linter also cleaned up trailing spaces.

This is my first PR so feel free to give feedback.