### PR TITLE
Fixed some mobile device asset tag issues.

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -263,10 +263,33 @@ def search_jamf_mobile(jamf_id):
         logging.debug("Returning a null value for the function.")
         return None
 
-# Function to update the asset tag in JAMF with an number passed from Snipe.
+# Function to update the asset tag of computers in JAMF with an number passed from Snipe.
 def update_jamf_asset_tag(jamf_id, asset_tag):
     api_url = "{}/JSSResource/computers/id/{}".format(jamfpro_base, jamf_id)
     payload = """<?xml version="1.0" encoding="UTF-8"?><computer><general><id>{}</id><asset_tag>{}</asset_tag></general></computer>""".format(jamf_id, asset_tag)
+    logging.debug('Making Get request against: {}\nPayload for the PUT request is: {}\nThe username, password, and headers can be found near the beginning of the output.'.format(api_url, payload))
+    response = requests.put(api_url, auth=(jamf_api_user, jamf_api_password), data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    if response.status_code == 201:
+        logging.debug("Got a 201 response. Returning: True")
+        return True
+    elif b'policies.ratelimit.QuotaViolation' in response.content:
+        logging.info('JAMFPro responded with error code: {} - Policy Ratelimit Quota Violation - when we tried to look up id: {} Waiting a bit to retry the lookup.'.format(response, jamf_id))
+        logging.warning('JAMFPro Ratelimit exceeded: pausing ')
+        time.sleep(75)
+        logging.info("Finished waiting. Retrying update...")
+        newresponse = update_jamf_asset_tag(jamf_id, asset_tag)
+        return newresponse
+    if response.status_code == 200:
+        logging.debug("Got a 200 response code. Returning the response: {}".format(response))
+        return response.json()
+    else:
+        logging.warning('Got back an error response code:{} - {}'.format(response.status_code, response.content))
+        return None
+        
+# Function to update the asset tag of mobile devices in JAMF with an number passed from Snipe.
+def update_jamf_mobiledevice_asset_tag(jamf_id, asset_tag):
+    api_url = "{}/JSSResource/mobiledevices/id/{}".format(jamfpro_base, jamf_id)
+    payload = """<?xml version="1.0" encoding="UTF-8"?><mobiledevice><general><id>{}</id><asset_tag>{}</asset_tag></general></mobiledevice>""".format(jamf_id, asset_tag)
     logging.debug('Making Get request against: {}\nPayload for the PUT request is: {}\nThe username, password, and headers can be found near the beginning of the output.'.format(api_url, payload))
     response = requests.put(api_url, auth=(jamf_api_user, jamf_api_password), data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 201:
@@ -667,4 +690,9 @@ for jamf_type in jamf_types:
             if jamf['general']['asset_tag'] != snipe['rows'][0]['asset_tag']:
                 logging.info("JAMF doesn't have the same asset tag as SNIPE so we'll update it because it should be authoritative.")
                 if snipe['rows'][0]['asset_tag'][0].isdigit():
-                    update_jamf_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
+                    if jamf_type == 'computers':
+                       update_jamf_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
+                       loggin.info("Device is a computer, updating computer record")
+                    elseif jamf_type == `mobile_devices`
+                      update_jamf_mobiledevice_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
+                      logging.info("Device is a mobile device, updating the mobile device record")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -693,6 +693,6 @@ for jamf_type in jamf_types:
                     if jamf_type == 'computers':
                        update_jamf_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
                        loggin.info("Device is a computer, updating computer record")
-                    elseif jamf_type == `mobile_devices`
+                    elif jamf_type == 'mobile_devices':
                       update_jamf_mobiledevice_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
                       logging.info("Device is a mobile device, updating the mobile device record")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -606,7 +606,12 @@ for jamf_type in jamf_types:
             else:
                 logging.info("Asset tag found in Jamf, setting it to: {}".format(jamf_asset_tag))            
             # Create the payload
-            newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
+            if jamf_type == 'mobile_devices':
+                logging.debug("Payload is being made for a mobile device")
+                newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
+            else
+                logging.debug("Payload is being made for a computer")
+                newasset = {'asset_tag': jamf_asset_tag,'model_id': modelnumbers['{}'.format(jamf['hardware']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}           
             if jamf['general']['serial_number'] == 'Not Available':
                 logging.warning("The serial number is not available in JAMF. This is normal for DEP enrolled devices that have not yet checked in for the first time. Since there's no serial number yet, we'll skip it for now.")
                 continue

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -289,7 +289,7 @@ def update_jamf_asset_tag(jamf_id, asset_tag):
 # Function to update the asset tag of mobile devices in JAMF with an number passed from Snipe.
 def update_jamf_mobiledevice_asset_tag(jamf_id, asset_tag):
     api_url = "{}/JSSResource/mobiledevices/id/{}".format(jamfpro_base, jamf_id)
-    payload = """<?xml version="1.0" encoding="UTF-8"?><mobiledevice><general><id>{}</id><asset_tag>{}</asset_tag></general></mobiledevice>""".format(jamf_id, asset_tag)
+    payload = """<?xml version="1.0" encoding="UTF-8"?><mobile_device><general><id>{}</id><asset_tag>{}</asset_tag></general></mobile_device>""".format(jamf_id, asset_tag)
     logging.debug('Making Get request against: {}\nPayload for the PUT request is: {}\nThe username, password, and headers can be found near the beginning of the output.'.format(api_url, payload))
     response = requests.put(api_url, auth=(jamf_api_user, jamf_api_password), data=payload, headers=jamfheaders, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     if response.status_code == 201:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -609,7 +609,7 @@ for jamf_type in jamf_types:
             if jamf_type == 'mobile_devices':
                 logging.debug("Payload is being made for a mobile device")
                 newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
-            else
+            elif jamf_type == 'computer'
                 logging.debug("Payload is being made for a computer")
                 newasset = {'asset_tag': jamf_asset_tag,'model_id': modelnumbers['{}'.format(jamf['hardware']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}           
             if jamf['general']['serial_number'] == 'Not Available':

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -93,7 +93,7 @@ if 'snipe-it' not in set(config):
     logging.debug("No valid config found in /etc Checking for a settings.conf in current directory ...")
     config.read("settings.conf")
 if 'snipe-it' not in set(config):
-    logging.debug("No valid config found in current folder.") 
+    logging.debug("No valid config found in current folder.")
     logging.error("No valid settings.conf was found. We'll need to quit while you figure out where the settings are at. You can check the README for valid locations.")
     raise SystemExit("Error: No valid settings.conf - Exiting.")
 
@@ -133,14 +133,14 @@ if 'api-mapping' in config:
     logging.error("Looks like you're using the old method for api-mapping. Please use computers-api-mapping and mobile_devices-api-mapping.")
     SETTINGS_CORRECT = False
 if not 'user-mapping' in config and (user_args.users or user_args.users_force or user_args.users_inverse):
-    logging.error("""You've chosen to check out assets to users in some capacity using a cmdline switch, but not specified how you want to 
+    logging.error("""You've chosen to check out assets to users in some capacity using a cmdline switch, but not specified how you want to
     search Snipe IT for the users from Jamf. Make sure you have a 'user-mapping' section in your settings.conf file.""")
     SETTINGS_CORRECT = False
 
 if not SETTINGS_CORRECT:
     raise SystemExit
 
-# Check the config file for valid jamf subsets. This is based off the JAMF API and if it's not right we can't map fields over to SNIPE properly. 
+# Check the config file for valid jamf subsets. This is based off the JAMF API and if it's not right we can't map fields over to SNIPE properly.
 logging.debug("Checking the settings.conf file for valid JAMF subsets of the JAMF API so mapping can occur properly.")
 for key in config['computers-api-mapping']:
     jamfsplit = config['computers-api-mapping'][key].split()
@@ -334,7 +334,7 @@ def get_snipe_models():
         logging.error('When we tried to retreive a list of models, Snipe-IT responded with error status code:{} - {}'.format(response.status_code, response.content))
         raise SystemExit("Snipe models API endpoint failed.")
 
-# Function to search snipe for a user 
+# Function to search snipe for a user
 def get_snipe_user_id(username):
     user_id_url = '{}/api/v1/users'.format(snipe_base)
     payload = {
@@ -445,7 +445,7 @@ def checkout_snipe_asset(user, asset_id, checked_out_user=None):
         return response
 
 ### Run Testing ###
-# Report if we're verifying SSL or not. 
+# Report if we're verifying SSL or not.
 logging.info("SSL Verification is set to: {}".format(user_args.do_not_verify_ssl))
 
 # Do some tests to see if the hosts are up.
@@ -505,7 +505,7 @@ elif user_args.mobiles:
     TotalNumber = len(jamf_types['mobile_devices']['mobile_devices'])
 else:
     for jamf_type in jamf_types:
-        TotalNumber += len(jamf_types[jamf_type][jamf_type]) 
+        TotalNumber += len(jamf_types[jamf_type][jamf_type])
 
 # Make sure we have a good list.
 if jamf_computer_list is not None:
@@ -518,7 +518,7 @@ else:
 if user_args.dryrun:
     raise SystemExit("Dryrun: Complete.")
 
-# From this point on, we're editing data. 
+# From this point on, we're editing data.
 logging.info('Starting to Update Inventory')
 CurrentNumber = 0
 
@@ -565,8 +565,12 @@ for jamf_type in jamf_types:
         if snipe is 'NoMatch':
             logging.info("Creating a new asset in snipe for JAMF ID {} - {}".format(jamf['general']['id'], jamf['general']['name']))
             # This section checks to see if the asset tag was already put into JAMF, if not it creates one with with Jamf's ID.
+            # If it is a Mobile record, then it add -m before the Jamf ID
             if jamf['general']['asset_tag'] is '':
                 jamf_asset_tag = 'jamfid-{}'.format(jamf['general']['id'])
+                if jamf_type == 'mobile_devices':
+                    index = jamf_asset_tag.find('-')
+                    jamf_asset_tag = jamf_asset_tag[:index] + "-m" + jamf_asset_tag[index:]
             else:
                 jamf_asset_tag = jamf['general']['asset_tag']
             try:
@@ -575,12 +579,9 @@ for jamf_type in jamf_types:
             except:
                 logging.info('No custom configuration found in settings.conf for asset tag name upon asset creation.')
             # Create the payload
-            if jamf_type == 'computers':
-                newasset = {'asset_tag': jamf_asset_tag,'model_id': modelnumbers['{}'.format(jamf['hardware']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
-            elif jamf_type == 'mobile_devices':
-                index = jamf_asset_tag.find('-')
-                jamf_asset_tag = jamf_asset_tag[:index] + "-m" + jamf_asset_tag[index:]
-                newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
+            logging.debug("Asset Tag is: {}".format(jamf_asset_tag))
+            # time.sleep(36000)
+            newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
             if jamf['general']['serial_number'] == 'Not Available':
                 logging.warning("The serial number is not available in JAMF. This is normal for DEP enrolled devices that have not yet checked in for the first time. Since there's no serial number yet, we'll skip it for now.")
                 continue
@@ -608,7 +609,7 @@ for jamf_type in jamf_types:
             elif jamf_type == 'mobile_devices':
                 jamf_time = jamf['general']['last_inventory_update']
             # Check to see that the JAMF record is newer than the previous Snipe update.
-            if jamf_time > snipe_time:
+            if jamf_time > snipe_time or snipe is 'NoMatch':
             # if True: # uncomment for testing
                 logging.debug("Updating the Snipe asset because JAMF has a more recent timestamp: {} > {}".format(jamf_time, snipe_time))
                 for snipekey in config['{}-api-mapping'.format(jamf_type)]:
@@ -655,6 +656,11 @@ for jamf_type in jamf_types:
                         checkout_snipe_asset(jamf['{}'.format(jamfsplit[0])]['{}'.format(jamfsplit[1])], snipe_id, snipe['rows'][0]['assigned_to'])
                     else:
                         logging.info("Can't checkout {} since the status isn't set to deployable".format(jamf['general']['name']))
+
+            else:
+                logging.info("Snipe Record is newer than the JAMF record. Nothing to sync. If this wrong, then force an inventory update in JAMF")
+                logging.debug("Not updating the Snipe asset because Snipe has a more recent timestamp: {} < {}".format(jamf_time, snipe_time))
+
             # Update/Sync the Snipe Asset Tag Number back to JAMF
             if jamf['general']['asset_tag'] != snipe['rows'][0]['asset_tag']:
                 logging.info("JAMF doesn't have the same asset tag as SNIPE so we'll update it because it should be authoritative.")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -566,21 +566,23 @@ for jamf_type in jamf_types:
             logging.info("Creating a new asset in snipe for JAMF ID {} - {}".format(jamf['general']['id'], jamf['general']['name']))
             # This section checks to see if the asset tag was already put into JAMF, if not it creates one with with Jamf's ID.
             # If it is a Mobile record, then it add -m before the Jamf ID
-            if jamf['general']['asset_tag'] is '':
-                jamf_asset_tag = 'jamfid-{}'.format(jamf['general']['id'])
-                if jamf_type == 'mobile_devices':
-                    index = jamf_asset_tag.find('-')
-                    jamf_asset_tag = jamf_asset_tag[:index] + "-m" + jamf_asset_tag[index:]
-            else:
-                jamf_asset_tag = jamf['general']['asset_tag']
             try:
+                # Get the asset_tag value from settings.conf, then try to pull it apart to get the asset tag from jamf in the field specified.
                 tag_split = config['snipe-it']['asset_tag'].split()
                 jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
             except:
                 logging.info('No custom configuration found in settings.conf for asset tag name upon asset creation.')
+            # Check to see if the above returns a value, if not then set the asset_tag to the jamf ID, add -m if it is mobile device
+            if jamf_asset_tag is '':
+                jamf_asset_tag = 'jamfid-{}'.format(jamf['general']['id'])
+                if jamf_type == 'mobile_devices':
+                    index = jamf_asset_tag.find('-')
+                    jamf_asset_tag = jamf_asset_tag[:index] + "-m" + jamf_asset_tag[index:]
+                    logging.debug("Mobile Device Detected, changing Asset Tag to: {}".format(jamf_asset_tag))
+                logging.info("Since no asset tag was found it is being set to: {}".format(jamf_asset_tag))
+            else:
+                logging.info("Asset tag found in Jamf, setting it to: {}".format(jamf_asset_tag))            
             # Create the payload
-            logging.debug("Asset Tag is: {}".format(jamf_asset_tag))
-            # time.sleep(36000)
             newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
             if jamf['general']['serial_number'] == 'Not Available':
                 logging.warning("The serial number is not available in JAMF. This is normal for DEP enrolled devices that have not yet checked in for the first time. Since there's no serial number yet, we'll skip it for now.")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -300,7 +300,7 @@ def update_jamf_mobiledevice_asset_tag(jamf_id, asset_tag):
         logging.warning('JAMFPro Ratelimit exceeded: pausing ')
         time.sleep(75)
         logging.info("Finished waiting. Retrying update...")
-        newresponse = update_jamf_asset_tag(jamf_id, asset_tag)
+        newresponse = update_jamf_mobiledevice_asset_tag(jamf_id, asset_tag)
         return newresponse
     if response.status_code == 200:
         logging.debug("Got a 200 response code. Returning the response: {}".format(response))

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -608,10 +608,10 @@ for jamf_type in jamf_types:
                 jamf_time = jamf['general']['report_date']
             elif jamf_type == 'mobile_devices':
                 jamf_time = jamf['general']['last_inventory_update']
-            # Check to see that the JAMF record is newer than the previous Snipe update.
+            # Check to see that the JAMF record is newer than the previous Snipe update, or if it is a new record in Snipe
             if jamf_time > snipe_time or snipe is 'NoMatch':
             # if True: # uncomment for testing
-                logging.debug("Updating the Snipe asset because JAMF has a more recent timestamp: {} > {}".format(jamf_time, snipe_time))
+                logging.debug("Updating the Snipe asset because JAMF has a more recent timestamp: {} > {} or the Snipe Record is new".format(jamf_time, snipe_time))
                 for snipekey in config['{}-api-mapping'.format(jamf_type)]:
                     jamfsplit = config['{}-api-mapping'.format(jamf_type)][snipekey].split()
                     for i, item in enumerate(jamfsplit):


### PR DESCRIPTION
Cancelled my last pull request as I discovered some bugs and typos. This one has been tested and is working.

Fixed the issue that a "-m" was being added to the asset tag even if there was an asset tag in JAMF and re-worked the section that creates a new asset if it does not exist in snipe to avoid the asset tag being accidentaly emptied or written incorrectly. Added a few more debug and info messages to help diagnose future issues. (Lines 590 - 607)
Added "def update_jamf_mobiledevice_asset_tag(jamf_id, asset_tag):" to add the asset tag to mobile records and added a mobile check at the end. This fixed the issue that the script would error out and/or update the wrong jamf record (there was no allowance for mobile_device updating of the asset tag). (Lines 288 - 310 and Lines 693 - 698)