### PR TITLE
Speed up user lookups, exact match only on checkout (user flag), syntax & typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Import/Sync Computers from JAMF to Snipe-IT
 ```
 usage: jamf2snipe [-h] [-v] [--dryrun] [-d] [--do_not_verify_ssl] [-r]
-                  [-u | -ui | -uf] [-m | -c]
+                  [--no_search] [-u | -ui | -uf] [-m | -c]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -14,8 +14,10 @@ optional arguments:
   -d, --debug           Sets logging to include additional DEBUG messages.
   --do_not_verify_ssl   Skips SSL verification for all requests. Helpful when
                         you use self-signed certificate.
-  -r, --ratelimited     Puts a half second delay between Snipe IT API calls to
-                        adhere to the standard 120/minute rate limit
+  -r, --ratelimited     Puts a half second delay between Snipe IT API calls
+                        to adhere to the standard 120/minute rate limit
+  --no_search           Doesn't search for any users if the specified fields
+                        in Jamf and Snipe don't match - case insensitive
   -u, --users           Checks out the item to the current user in Jamf if
                         it's not already deployed
   -ui, --users_inverse  Checks out the item to the current user in Jamf if
@@ -116,3 +118,7 @@ More information can be found in the ./jamf2snipe file about associations and [v
 It is *always* a good idea to create a test environment to ensure everything works as expected before running anything in production.
 
 Because `jamf2snipe` only ever writes the asset_tag for a matching serial number back to Jamf, testing with your production JAMF Pro is OK. However, this can overwrite good data in Snipe. You can spin up a Snipe instance in Docker pretty quickly ([see the Snipe docs](https://snipe-it.readme.io/docs/docker)).
+
+## Contributing
+
+Thanks to all of the people that have already contributed to this project! If you have something you'd like to add please help by forking this project then creating a pull request to the `devel` branch. When working on new features, please try to keep existing configs running in the same manner with no changes. When possible, open up an issue and reference it when you make your pull request.

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -636,7 +636,7 @@ for jamf_type in jamf_types:
                         jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
                     except:
                         raise SystemError('No such attribute {} in the jamf payload. Please check your settings.conf file'.format(tag_split))
-                if jamf_asset_tag is None:
+                if jamf_asset_tag is None or jamf_asset_tag is '':
                     logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')
                     if jamf_type == 'mobile_devices':
                         jamf_asset_tag = 'jamfid-m-{}'.format(jamf['general']['id'])
@@ -681,7 +681,7 @@ for jamf_type in jamf_types:
             elif jamf_type == 'mobile_devices':
                 jamf_time = jamf['general']['last_inventory_update']
             # Check to see that the JAMF record is newer than the previous Snipe update, or if it is a new record in Snipe
-            if jamf_time > snipe_time or snipe is 'NoMatch':
+            if jamf_time > snipe_time: # or snipe is 'NoMatch': < Unreachable, maybe changed down the line
             # if True: # uncomment for testing
                 logging.debug("Updating the Snipe asset because JAMF has a more recent timestamp: {} > {} or the Snipe Record is new".format(jamf_time, snipe_time))
                 for snipekey in config['{}-api-mapping'.format(jamf_type)]:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -632,7 +632,10 @@ for jamf_type in jamf_types:
                 logging.debug('No asset tag found in Jamf, checking settings.conf for alternative specified field.')
                 if 'asset_tag' in config['snipe-it']:
                     tag_split = config['snipe-it']['asset_tag'].split()
-                    jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
+                    try:
+                        jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
+                    except:
+                        raise SystemError('No such attribute {} in the jamf payload. Please check your settings.conf file'.format(tag_split))
                 if jamf_asset_tag is None:
                     logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')
                     if jamf_type == 'mobile_devices':
@@ -643,9 +646,11 @@ for jamf_type in jamf_types:
                 jamf_asset_tag = jamf['general']['asset_tag']
             # Create the payload
             if jamf_type == 'mobile_devices':
+                logging.debug("Payload is being made for a mobile device")
                 newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
             elif jamf_type == 'computers':
-                newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['hardware']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
+                logging.debug("Payload is being made for a computer")
+                newasset = {'asset_tag': jamf_asset_tag,'model_id': modelnumbers['{}'.format(jamf['hardware']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}           
             if jamf['general']['serial_number'] == 'Not Available':
                 logging.warning("The serial number is not available in JAMF. This is normal for DEP enrolled devices that have not yet checked in for the first time. Since there's no serial number yet, we'll skip it for now.")
                 continue

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -60,6 +60,7 @@ runtimeargs.add_argument("--dryrun", help="This checks your config and tries to 
 runtimeargs.add_argument("-d", "--debug", help="Sets logging to include additional DEBUG messages.", action="store_true")
 runtimeargs.add_argument('--do_not_verify_ssl', help="Skips SSL verification for all requests. Helpful when you use self-signed certificate.", action="store_false")
 runtimeargs.add_argument("-r", "--ratelimited", help="Puts a half second delay between Snipe IT API calls to adhere to the standard 120/minute rate limit", action="store_true")
+runtimeargs.add_argument("--no_search", help="Doesn't search for any users if the specified fields in Jamf and Snipe don't match - case insensitive", action="store_true")
 user_opts = runtimeargs.add_mutually_exclusive_group()
 user_opts.add_argument("-u", "--users", help="Checks out the item to the current user in Jamf if it's not already deployed", action="store_true")
 user_opts.add_argument("-ui", "--users_inverse", help="Checks out the item to the current user in Jamf if it's already deployed", action="store_true")
@@ -337,31 +338,33 @@ def get_snipe_models():
 def get_snipe_users(previous=[]):
     user_id_url = '{}/api/v1/users'.format(snipe_base)
     payload = {
-        'limit': 80,
+        'limit': 100,
         'offset': len(previous)
     }
     logging.debug('The payload for the snipe users GET is {}'.format(payload))
     response = requests.get(user_id_url, headers=snipeheaders, json=payload, hooks={'response': request_handler})
     response_json = response.json()
     current = response_json['rows']
-    print(str(response_json['total']) + " " + str(len(current)) + " " + str(len(previous)))
     if len(previous) is not 0:
         current = previous + current
     if response_json['total'] > len(current):
+        logging.debug('We have more than 100 users, get the next page - total: {} current: {}'.format(response_json['total'], len(current)))
         return get_snipe_users(current)
     else:
-        users = {}
-        for user in current:
-            users[user[config['user-mapping']['snipe_user_attribute']]] = user['id']
-        return users
+        return current
 
 # Function to search snipe for a user 
 def get_snipe_user_id(username):
-    if username in snipe_users:
-        id = snipe_users[username]
-        return id
-    else:
-        logging.debug('No matches in snipe_users for {}, querying the API for the next closest match'.format(username))
+    username = username.lower()
+    for user in snipe_users:
+        for value in user.values():
+            if str(value).lower() == username:
+                id = user['id']
+                return id
+    if user_args.no_search:
+        logging.debug("No matches in snipe_users for {}, not querying the API for the next closest match since we've been told not to".format(username))
+        return "NotFound"
+    logging.debug('No matches in snipe_users for {}, querying the API for the next closest match'.format(username))
     user_id_url = '{}/api/v1/users'.format(snipe_base)
     payload = {
         'search':username,
@@ -644,8 +647,8 @@ for jamf_type in jamf_types:
             elif jamf_type == 'mobile_devices':
                 jamf_time = jamf['general']['last_inventory_update']
             # Check to see that the JAMF record is newer than the previous Snipe update.
-            if jamf_time > snipe_time:
-            # if True: # uncomment for testing
+            # if jamf_time > snipe_time:
+            if True: # uncomment for testing
                 logging.debug("Updating the Snipe asset because JAMF has a more recent timestamp: {} > {}".format(jamf_time, snipe_time))
                 for snipekey in config['{}-api-mapping'.format(jamf_type)]:
                     jamfsplit = config['{}-api-mapping'.format(jamf_type)][snipekey].split()
@@ -686,8 +689,12 @@ for jamf_type in jamf_types:
                         else:
                             logging.debug("Skipping the payload, because it already exists, or the Snipe key we're mapping to doesn't.")
                 if ((user_args.users or user_args.users_inverse) and (snipe['rows'][0]['assigned_to'] == None) == user_args.users) or user_args.users_force:
+                    
                     if snipe['rows'][0]['status_label']['status_meta'] in ('deployable', 'deployed'):
                         jamfsplit = config['user-mapping']['jamf_api_field'].split()
+                        if jamfsplit[1] not in jamf[jamfsplit[0]]:
+                            logging.info("Couldn't find {} for this device in {}, not checking it out.".format(jamfsplit[1], jamfsplit[0]))
+                            continue
                         checkout_snipe_asset(jamf['{}'.format(jamfsplit[0])]['{}'.format(jamfsplit[1])], snipe_id, snipe['rows'][0]['assigned_to'])
                     else:
                         logging.info("Can't checkout {} since the status isn't set to deployable".format(jamf['general']['name']))

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -356,6 +356,8 @@ def get_snipe_users(previous=[]):
 
 # Function to search snipe for a user 
 def get_snipe_user_id(username):
+    if username == '':
+        return "NotFound"
     username = username.lower()
     for user in snipe_users:
         for value in user.values():
@@ -603,21 +605,20 @@ for jamf_type in jamf_types:
             logging.info("Creating a new asset in snipe for JAMF ID {} - {}".format(jamf['general']['id'], jamf['general']['name']))
             # This section checks to see if the asset tag was already put into JAMF, if not it creates one with with Jamf's ID.
             if jamf['general']['asset_tag'] is '':
-                jamf_asset_tag = 'jamfid-{}'.format(jamf['general']['id'])
+                logging.debug('No asset tag found in Jamf, checking settings.conf for alternative specified field.')
+                if 'asset_tag' in config['snipe-it']:
+                    tag_split = config['snipe-it']['asset_tag'].split()
+                    jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
+                else:
+                    logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')
+                    if jamf_type == 'mobile_devices':
+                        jamf_asset_tag = 'jamfid-m-{}'.format(jamf['general']['id'])
+                    else:
+                        jamf_asset_tag = 'jamfid-{}'.format(jamf['general']['id'])
             else:
                 jamf_asset_tag = jamf['general']['asset_tag']
-            try:
-                tag_split = config['snipe-it']['asset_tag'].split()
-                jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
-            except:
-                logging.info('No custom configuration found in settings.conf for asset tag name upon asset creation.')
             # Create the payload
-            if jamf_type == 'computers':
-                newasset = {'asset_tag': jamf_asset_tag,'model_id': modelnumbers['{}'.format(jamf['hardware']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
-            elif jamf_type == 'mobile_devices':
-                index = jamf_asset_tag.find('-')
-                jamf_asset_tag = jamf_asset_tag[:index] + "-m" + jamf_asset_tag[index:]
-                newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
+            newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
             if jamf['general']['serial_number'] == 'Not Available':
                 logging.warning("The serial number is not available in JAMF. This is normal for DEP enrolled devices that have not yet checked in for the first time. Since there's no serial number yet, we'll skip it for now.")
                 continue

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -125,6 +125,20 @@ jamfheaders = {'Accept': 'application/json'}
 snipeheaders = {'Authorization': 'Bearer {}'.format(apiKey),'Accept': 'application/json','Content-Type':'application/json'}
 logging.debug('Request headers for JamfPro will be: {}\nRequest headers for Snipe will be: {}'.format(jamfheaders, snipeheaders))
 
+# Check the config file for correct headers
+
+# Do some tests to see if the user has updated their settings.conf file
+SETTINGS_CORRECT = True
+if 'api-mapping' in config:
+    logging.error("Looks like you're using the old method for api-mapping. Please use computers-api-mapping and mobile_devices-api-mapping.")
+    SETTINGS_CORRECT = False
+if not 'user-mapping' in config and (user_args.users or user_args.users_force or user_args.users_inverse):
+    logging.error("""You've chosen to check out assets to users in some capacity using a cmdline switch, but not specified how you want to 
+    search Snipe IT for the users from Jamf. Make sure you have a 'user-mapping' section in your settings.conf file.""")
+    SETTINGS_CORRECT = False
+
+if not SETTINGS_CORRECT:
+    raise SystemExit
 
 # Check the config file for valid jamf subsets. This is based off the JAMF API and if it's not right we can't map fields over to SNIPE properly. 
 logging.debug("Checking the settings.conf file for valid JAMF subsets of the JAMF API so mapping can occur properly.")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -609,7 +609,7 @@ for jamf_type in jamf_types:
                 if 'asset_tag' in config['snipe-it']:
                     tag_split = config['snipe-it']['asset_tag'].split()
                     jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
-                else:
+                if jamf_asset_tag == '':
                     logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')
                     if jamf_type == 'mobile_devices':
                         jamf_asset_tag = 'jamfid-m-{}'.format(jamf['general']['id'])

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -738,7 +738,7 @@ for jamf_type in jamf_types:
                 if snipe['rows'][0]['asset_tag'][0].isdigit():
                     if jamf_type == 'computers':
                        update_jamf_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
-                       loggin.info("Device is a computer, updating computer record")
+                       logging.info("Device is a computer, updating computer record")
                     elif jamf_type == 'mobile_devices':
                       update_jamf_mobiledevice_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
                       logging.info("Device is a mobile device, updating the mobile device record")

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -335,6 +335,7 @@ def get_snipe_models():
         logging.error('When we tried to retreive a list of models, Snipe-IT responded with error status code:{} - {}'.format(response.status_code, response.content))
         raise SystemExit("Snipe models API endpoint failed.")
 
+# Recursive function returns all users in a Snipe Instance, 100 at a time.
 def get_snipe_users(previous=[]):
     user_id_url = '{}/api/v1/users'.format(snipe_base)
     payload = {

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -173,7 +173,7 @@ def request_handler(r, *args, **kwargs):
         snipe_api_rate = snipe_api_count / time_elapsed
         if snipe_api_rate > 1.95:
             sleep_time = 0.5 + (snipe_api_rate - 1.95)
-            logging.info('Going over snipe rate limit of 120/minute ({}/minute), sleeping for {}'.format(snipe_api_rate,sleep_time))
+            logging.debug('Going over snipe rate limit of 120/minute ({}/minute), sleeping for {}'.format(snipe_api_rate,sleep_time))
             time.sleep(sleep_time)
         logging.debug("Made {} requests to Snipe IT in {} seconds, with a request being sent every {} seconds".format(snipe_api_count, time_elapsed, snipe_api_rate))
     if '"messages":429' in r.text:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -173,7 +173,7 @@ def request_handler(r, *args, **kwargs):
         snipe_api_rate = snipe_api_count / time_elapsed
         if snipe_api_rate > 1.95:
             sleep_time = 0.5 + (snipe_api_rate - 1.95)
-            logging.debug('Going over snipe rate limit of 120/minute ({}/minute), sleeping for {}'.format(snipe_api_rate,sleep_time))
+            logging.info('Going over snipe rate limit of 120/minute ({}/minute), sleeping for {}'.format(snipe_api_rate,sleep_time))
             time.sleep(sleep_time)
         logging.debug("Made {} requests to Snipe IT in {} seconds, with a request being sent every {} seconds".format(snipe_api_count, time_elapsed, snipe_api_rate))
     if '"messages":429' in r.text:
@@ -334,8 +334,34 @@ def get_snipe_models():
         logging.error('When we tried to retreive a list of models, Snipe-IT responded with error status code:{} - {}'.format(response.status_code, response.content))
         raise SystemExit("Snipe models API endpoint failed.")
 
+def get_snipe_users(previous=[]):
+    user_id_url = '{}/api/v1/users'.format(snipe_base)
+    payload = {
+        'limit': 80,
+        'offset': len(previous)
+    }
+    logging.debug('The payload for the snipe users GET is {}'.format(payload))
+    response = requests.get(user_id_url, headers=snipeheaders, json=payload, hooks={'response': request_handler})
+    response_json = response.json()
+    current = response_json['rows']
+    print(str(response_json['total']) + " " + str(len(current)) + " " + str(len(previous)))
+    if len(previous) is not 0:
+        current = previous + current
+    if response_json['total'] > len(current):
+        return get_snipe_users(current)
+    else:
+        users = {}
+        for user in current:
+            users[user[config['user-mapping']['snipe_user_attribute']]] = user['id']
+        return users
+
 # Function to search snipe for a user 
 def get_snipe_user_id(username):
+    if username in snipe_users:
+        id = snipe_users[username]
+        return id
+    else:
+        logging.debug('No matches in snipe_users for {}, querying the API for the next closest match'.format(username))
     user_id_url = '{}/api/v1/users'.format(snipe_base)
     payload = {
         'search':username,
@@ -498,6 +524,13 @@ jamf_types = {
     'computers': jamf_computer_list,
     'mobile_devices': jamf_mobile_list
 }
+
+# Get a list of users from Snipe if the user has specified
+# they're syncing users
+
+if user_args.users or user_args.users_force or user_args.users_inverse:
+    snipe_users = get_snipe_users()
+
 TotalNumber = 0
 if user_args.computers:
     TotalNumber = len(jamf_types['computers']['computers'])
@@ -590,6 +623,9 @@ for jamf_type in jamf_types:
                     continue
                 if user_args.users or user_args.users_force or user_args.users_inverse:
                     jamfsplit = config['user-mapping']['jamf_api_field'].split()
+                    if jamfsplit[1] not in jamf[jamfsplit[0]]:
+                        logging.info("Couldn't find {} for this device in {}, not checking it out.".format(jamfsplit[1], jamfsplit[0]))
+                        continue
                     logging.info('Checking out new item {} to user {}'.format(jamf['general']['name'], jamf['{}'.format(jamfsplit[0])]['{}'.format(jamfsplit[1])]))
                     checkout_snipe_asset(jamf['{}'.format(jamfsplit[0])]['{}'.format(jamfsplit[1])],new_snipe_asset[1].json()['payload']['id'], "NewAsset")
 

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -747,3 +747,5 @@ for jamf_type in jamf_types:
                     elif jamf_type == 'mobile_devices':
                       update_jamf_mobiledevice_asset_tag("{}".format(jamf['general']['id']), '{}'.format(snipe['rows'][0]['asset_tag']))
                       logging.info("Device is a mobile device, updating the mobile device record")
+
+logging.debug('Total amount of API calls made: {}'.format(snipe_api_count))

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -609,7 +609,7 @@ for jamf_type in jamf_types:
                 if 'asset_tag' in config['snipe-it']:
                     tag_split = config['snipe-it']['asset_tag'].split()
                     jamf_asset_tag = jamf['{}'.format(tag_split[0])]['{}'.format(tag_split[1])]
-                if jamf_asset_tag == '':
+                if jamf_asset_tag is None:
                     logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')
                     if jamf_type == 'mobile_devices':
                         jamf_asset_tag = 'jamfid-m-{}'.format(jamf['general']['id'])

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -605,6 +605,7 @@ for jamf_type in jamf_types:
             logging.info("Creating a new asset in snipe for JAMF ID {} - {}".format(jamf['general']['id'], jamf['general']['name']))
             # This section checks to see if the asset tag was already put into JAMF, if not it creates one with with Jamf's ID.
             if jamf['general']['asset_tag'] is '':
+                jamf_asset_tag = None
                 logging.debug('No asset tag found in Jamf, checking settings.conf for alternative specified field.')
                 if 'asset_tag' in config['snipe-it']:
                     tag_split = config['snipe-it']['asset_tag'].split()
@@ -613,12 +614,15 @@ for jamf_type in jamf_types:
                     logging.debug('No custom configuration found in settings.conf for asset tag name upon asset creation.')
                     if jamf_type == 'mobile_devices':
                         jamf_asset_tag = 'jamfid-m-{}'.format(jamf['general']['id'])
-                    else:
+                    elif jamf_type == 'computers':
                         jamf_asset_tag = 'jamfid-{}'.format(jamf['general']['id'])
             else:
                 jamf_asset_tag = jamf['general']['asset_tag']
             # Create the payload
-            newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
+            if jamf_type == 'mobile_devices':
+                newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['general']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
+            elif jamf_type == 'computers':
+                newasset = {'asset_tag': jamf_asset_tag, 'model_id': modelnumbers['{}'.format(jamf['hardware']['model_identifier'])], 'name': jamf['general']['name'], 'status_id': defaultStatus,'serial': jamf['general']['serial_number']}
             if jamf['general']['serial_number'] == 'Not Available':
                 logging.warning("The serial number is not available in JAMF. This is normal for DEP enrolled devices that have not yet checked in for the first time. Since there's no serial number yet, we'll skip it for now.")
                 continue

--- a/settings.conf
+++ b/settings.conf
@@ -20,6 +20,7 @@ mobile_model_category_id = 3
 name = general name
 _snipeit_mac_address_1 = general mac_address
 
+
 [mobile_devices-api-mapping]
 _snipeit_imei_4	= network imei
 name = general name


### PR DESCRIPTION
### User facing changes:

Addition of --no_search should help with Fixes #25 

### Behind the scenes:

get_snipe_users is a new function that returns the rows of users from Snipe
get_snipe_user_id has been updated to reference 'snipe_users' before referring to the API

Might want to refine this before merging into master in case some try to use realname instead of email or something... It'll just grab the first case insensitive match in that array. Could make it faster by saying you know what field you want to match to in Snipe. 

Fixes #39

Typo & Syntax
Fixes #38 
Fixes #37 
Fixes #36 