### PR TITLE
snipeit user search - alphabetize result

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -362,7 +362,9 @@ def get_snipe_user_id(username):
     user_id_url = '{}/api/v1/users'.format(snipe_base)
     payload = {
         'search':username,
-        'limit':1
+        'limit':1,
+        'sort':'username',
+        'order':'asc'
     }
     logging.debug('The payload for the snipe user search is: {}'.format(payload))
     response = requests.get(user_id_url, headers=snipeheaders, json=payload, hooks={'response': request_handler})


### PR DESCRIPTION
Greetings @ParadoxGuitarist!  I work with @snipe, and we received an issue that I'd like to 'shoot across your bow'.

Currently the search-users api endpoint returns users by their "created_at" columns.  Unfortunately, if I have users
```
ana@snipeitapp.com
dana@snipeitapp.com
```

In our case `dana@snipeitapp.com` was created _before_ ana - the search endpoint will return `dana@snipeitapp.com` on an unsorted search for `ana@snipeitapp.com`.

I've updated the parameters in this PR - let me know what you think sir!

(And deep thanks from myself and all of us @ snipeitapp.com <3)