### PR TITLE
Change the snipe-it url to be https by default

### DIFF
--- a/settings.conf
+++ b/settings.conf
@@ -5,7 +5,7 @@ password = a-valid-password
 
 [snipe-it]
 #Required
-url = http://FQDN.your.snipe.instance.com
+url = https://FQDN.your.snipe.instance.com
 apikey = YOUR-API-KEY-HERE
 manufacturer_id = 2
 defaultStatus = 2 


### PR DESCRIPTION
When testing this on our instance the first import / sync failed silently as Snipe-It's SaaS platform redirects http to https. 