### PR TITLE
Fixed two condition checks for confirming updating fields

### DIFF
--- a/jamf2snipe
+++ b/jamf2snipe
@@ -444,6 +444,10 @@ def update_snipe_asset(snipe_id, payload):
         logging.debug("Got back status code: 200 - Checking the payload updated properly: If you error here it's because you configure the API mapping right.")
         jsonresponse = response.json()
         for key in payload:
+            if key == 'purchase_date':
+                payload[key] = payload[key] + " 00:00:00"
+            if payload[key] is '':
+                payload[key] = None
             if jsonresponse['payload'][key] != payload[key]:
                 logging.warning('Unable to update ID: {}. We failed to update the {} field with "{}"'.format(snipe_id, key, payload[key]))
                 goodupdate = False


### PR DESCRIPTION
I fixed two condition checks to make sure the data from Jamf and the data from Snipe are aligned.

During a sync, these fields are updating correctly but showing as failed because the data doesn't match at the time of comparison.

Snipe adds ` 00:00:00` to the purchase_date output, and json output reports None for a blank value while the payload[key] contains an empty string ''.

By doing these two conditional checks, I stop the warnings for a machine updating the purchase date, and for an empty extension attribute.