### PR TITLE
Interpolate environment variables in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ Some example API mappings can be found below:
 
 More information can be found in the ./jamf2snipe file about associations and [valid subsets](https://github.com/ParadoxGuitarist/jamf2snipe/blob/master/jamf2snipe#L33).
 
+### Environment variables
+
+Config values can be set through environment variables, e.g.:
+```
+[jamf]
+url = $JAMF_URL
+username = $JAMF_USERNAME
+password = $JAMF_PASSWORD
+```
+
 ## Testing
 
 It is *always* a good idea to create a test environment to ensure everything works as expected before running anything in production.

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -52,6 +52,12 @@ import time
 import configparser
 import argparse
 import logging
+import os
+
+class EnvironmentInterpolation(configparser.BasicInterpolation):
+    def before_get(self, parser, section, option, value, defaults):
+        value = super().before_get(parser, section, option, value, defaults)
+        return os.path.expandvars(value)
 
 # Set us up for using runtime arguments by defining them.
 runtimeargs = argparse.ArgumentParser()
@@ -86,7 +92,7 @@ if user_args.dryrun:
 
 # Find a valid settings.conf file.
 logging.info("Searching for a valid settings.conf file.")
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(interpolation=EnvironmentInterpolation())
 logging.debug("Checking for a settings.conf in /opt/jamf2snipe ...")
 config.read("/opt/jamf2snipe/settings.conf")
 if 'snipe-it' not in set(config):


### PR DESCRIPTION
This is helpful to run the same script in multiple environments, where
adapting the `settings.conf` file might not be possible or desirable.
