### PR TITLE
Fix GET requests and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Lastly, if the asset_tag field is blank in JAMF when it is being created in Snip
 
 - Python3 is installed on your system with the requests, json, time, and configparser python libs installed.
 - Network access to both your JAMF and Snipe-IT environments.
-- A JAMF username and password that has read & write permissions for computer assets.
+- A JAMF username and password that has read & write permissions for computer assets, mobile device assets, and users.
   - Computers: Read, Update
+  - Mobile Devices: Read, Update
+  - Users: Read, Update
 - Snipe API key for a user that has edit/create permissions for assets and models. Snipe-IT documentation instructions for creating API keys: [https://snipe-it.readme.io/reference#generating-api-tokens](https://snipe-it.readme.io/reference#generating-api-tokens)
 
 ## Installation:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 # jamf2snipe - Inventory Import
 #
 # ABOUT:
@@ -368,7 +368,7 @@ def get_snipe_users(previous=[]):
         'offset': len(previous)
     }
     logging.debug('The payload for the snipe users GET is {}'.format(payload))
-    response = requests.get(user_id_url, headers=snipeheaders, json=payload, hooks={'response': request_handler})
+    response = requests.get(user_id_url, headers=snipeheaders, params=payload, hooks={'response': request_handler})
     response_json = response.json()
     current = response_json['rows']
     if len(previous) is not 0:
@@ -401,7 +401,7 @@ def get_snipe_user_id(username):
         'order':'asc'
     }
     logging.debug('The payload for the snipe user search is: {}'.format(payload))
-    response = requests.get(user_id_url, headers=snipeheaders, json=payload, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
+    response = requests.get(user_id_url, headers=snipeheaders, params=payload, verify=user_args.do_not_verify_ssl, hooks={'response': request_handler})
     try:
         return response.json()['rows'][0]['id']
     except:

--- a/jamf2snipe
+++ b/jamf2snipe
@@ -362,7 +362,9 @@ def get_snipe_user_id(username):
     user_id_url = '{}/api/v1/users'.format(snipe_base)
     payload = {
         'search':username,
-        'limit':1
+        'limit':1,
+        'sort':'username',
+        'order':'asc'
     }
     logging.debug('The payload for the snipe user search is: {}'.format(payload))
     response = requests.get(user_id_url, headers=snipeheaders, json=payload, hooks={'response': request_handler})


### PR DESCRIPTION
This fixes the various GET requests to correctly pass parameters in the query string instead of in the body; GET requests are not supposed to have a request body, and some servers or load balancers will reject GET requests that have them.

This also updates the readme to indicate that the Jamf user needs to have Mobile Device and User permissions to operate properly. User permissions are unfortunately required to update Computer records due to some weirdness in their implementation (for more info, see [this thread](https://www.jamf.com/jamf-nation/discussions/18232/privileges-required-to-update-computer-records) and [this thread](https://www.jamf.com/jamf-nation/discussions/17846/9-81-issue-with-api-update)).